### PR TITLE
Ban API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,9 +2835,12 @@ dependencies = [
  "actix-web",
  "rand",
  "serde",
+ "sqlx",
  "thiserror",
+ "tracing",
  "waygate-config",
  "waygate-connection",
+ "waygate-database",
  "waygate-message",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,6 +2842,7 @@ dependencies = [
  "waygate-connection",
  "waygate-database",
  "waygate-message",
+ "waygate-session",
 ]
 
 [[package]]
@@ -2952,8 +2953,19 @@ dependencies = [
  "waygate-message",
  "waygate-pool",
  "waygate-rpc",
+ "waygate-session",
  "waygate-steam",
  "waygate-wire",
+]
+
+[[package]]
+name = "waygate-session"
+version = "0.1.0"
+dependencies = [
+ "sqlx",
+ "thiserror",
+ "tracing",
+ "waygate-database",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/config",
     "crates/connection",
     "crates/rpc",
+    "crates/session",
 ]
 
 [profile.release]
@@ -105,3 +106,6 @@ path = "crates/connection"
 
 [workspace.dependencies.waygate-rpc]
 path = "crates/rpc"
+
+[workspace.dependencies.waygate-session]
+path = "crates/session"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -32,3 +32,6 @@ workspace = true
 
 [dependencies.waygate-database]
 workspace = true
+
+[dependencies.waygate-session]
+workspace = true

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 actix-web = "4"
 
+[dependencies.sqlx]
+workspace = true
+
 [dependencies.thiserror]
 workspace = true
 
@@ -15,6 +18,9 @@ workspace = true
 [dependencies.rand]
 workspace = true
 
+[dependencies.tracing]
+workspace = true
+
 [dependencies.waygate-config]
 workspace = true
 
@@ -22,4 +28,7 @@ workspace = true
 workspace = true
 
 [dependencies.waygate-connection]
+workspace = true
+
+[dependencies.waygate-database]
 workspace = true

--- a/crates/api/src/ban.rs
+++ b/crates/api/src/ban.rs
@@ -1,0 +1,59 @@
+use std::error::Error;
+
+use actix_web::{delete, get, post, Responder};
+use actix_web::web::{Json, Path};
+use serde::{Deserialize, Serialize};
+use sqlx::{query_as, Row};
+use waygate_database::database_connection;
+
+#[get("/ban")]
+async fn get_ban() -> Result<impl Responder, Box<dyn Error>>{
+    let mut connection = database_connection().await?;
+    let entries = query_as::<_, Ban>("SELECT * FROM bans")
+        .fetch_all(&mut *connection)
+        .await?
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    Ok(Json(entries))
+}
+
+#[post("/ban")]
+async fn post_ban(request: Json<NewBan>) -> Result<impl Responder, Box<dyn Error>>{
+    let mut connection = database_connection().await?;
+    let ban_id: i32 = sqlx::query("INSERT INTO bans (external_id) VALUES ($1) RETURNING ban_id")
+        .bind(&request.external_id)
+        .fetch_one(&mut *connection)
+        .await?
+        .get("ban_id");
+
+    tracing::info!("Banned player. external_id = {}", &request.external_id);
+
+    Ok(Json(ban_id))
+}
+
+#[delete("/ban/{external_id}")]
+async fn delete_ban(external_id: Path<(String,)>) -> Result<impl Responder, Box<dyn Error>>{
+    let external_id = &external_id.into_inner().0;
+
+    let mut connection = database_connection().await?;
+    sqlx::query("DELETE FROM bans WHERE external_id = $1")
+        .bind(external_id)
+        .execute(&mut *connection)
+        .await?;
+
+    tracing::info!("Lifted ban for player. external_id = {external_id}");
+
+    Ok(Json(true))
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+struct Ban {
+    ban_id: i32,
+    external_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct NewBan {
+    external_id: String,
+}

--- a/crates/api/src/ban.rs
+++ b/crates/api/src/ban.rs
@@ -1,49 +1,49 @@
 use std::error::Error;
 
+use actix_web::web::{Json, Path, Query};
 use actix_web::{delete, get, post, Responder};
-use actix_web::web::{Json, Path};
 use serde::{Deserialize, Serialize};
-use sqlx::{query_as, Row};
+use sqlx::{query, query_as, Row};
 use waygate_database::database_connection;
+use waygate_session::{clear_bans, create_ban};
+
+use crate::pagination::{PaginatedResponse, PaginationParameters};
+
+const DEFAULT_INDEX_LIMIT: i32 = 100;
 
 #[get("/ban")]
-async fn get_ban() -> Result<impl Responder, Box<dyn Error>>{
+async fn get_ban(
+    Query(pagination): Query<PaginationParameters>,
+) -> Result<impl Responder, Box<dyn Error>> {
     let mut connection = database_connection().await?;
-    let entries = query_as::<_, Ban>("SELECT * FROM bans")
+
+    // TODO: make a single query
+    let total: i64 = query("SELECT COUNT(ban_id) as total FROM bans")
+        .fetch_one(&mut *connection)
+        .await?
+        .get("total");
+
+    let entries = query_as::<_, Ban>("SELECT * FROM bans ORDER BY ban_id LIMIT $1 OFFSET $2")
+        .bind(pagination.limit.as_ref().unwrap_or(&DEFAULT_INDEX_LIMIT))
+        .bind(pagination.offset.as_ref().unwrap_or(&0))
         .fetch_all(&mut *connection)
         .await?
         .into_iter()
         .collect::<Vec<_>>();
 
-    Ok(Json(entries))
+    Ok(Json(PaginatedResponse::new(total, entries)))
 }
 
 #[post("/ban")]
-async fn post_ban(request: Json<NewBan>) -> Result<impl Responder, Box<dyn Error>>{
-    let mut connection = database_connection().await?;
-    let ban_id: i32 = sqlx::query("INSERT INTO bans (external_id) VALUES ($1) RETURNING ban_id")
-        .bind(&request.external_id)
-        .fetch_one(&mut *connection)
-        .await?
-        .get("ban_id");
-
-    tracing::info!("Banned player. external_id = {}", &request.external_id);
-
+async fn post_ban(request: Json<NewBan>) -> Result<impl Responder, Box<dyn Error>> {
+    let ban_id = create_ban(&request.external_id).await?;
     Ok(Json(ban_id))
 }
 
 #[delete("/ban/{external_id}")]
-async fn delete_ban(external_id: Path<(String,)>) -> Result<impl Responder, Box<dyn Error>>{
+async fn delete_ban(external_id: Path<(String,)>) -> Result<impl Responder, Box<dyn Error>> {
     let external_id = &external_id.into_inner().0;
-
-    let mut connection = database_connection().await?;
-    sqlx::query("DELETE FROM bans WHERE external_id = $1")
-        .bind(external_id)
-        .execute(&mut *connection)
-        .await?;
-
-    tracing::info!("Lifted ban for player. external_id = {external_id}");
-
+    clear_bans(external_id).await?;
     Ok(Json(true))
 }
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2,6 +2,7 @@ use actix_web::{get, http::header::ContentType, App, HttpResponse, HttpServer, R
 use thiserror::Error;
 
 mod auth;
+mod ban;
 mod notify;
 
 use auth::CheckKey;
@@ -20,6 +21,9 @@ pub async fn serve_api(bind: &str, api_key: &str) -> Result<(), ApiError> {
                     .wrap(CheckKey::new(&api_key))
                     .service(health)
                     .service(notify::notify_message)
+                    .service(ban::get_ban)
+                    .service(ban::post_ban)
+                    .service(ban::delete_ban)
             })
             .bind(bind)?
             .run()

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 mod auth;
 mod ban;
 mod notify;
+mod pagination;
 
 use auth::CheckKey;
 

--- a/crates/api/src/pagination.rs
+++ b/crates/api/src/pagination.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+
+#[derive(Deserialize)]
+pub struct PaginationParameters {
+    pub limit: Option<i32>,
+    pub offset: Option<i32>,
+}
+
+#[derive(Serialize)]
+pub struct PaginatedResponse<T> {
+    pagination: PaginatedResponseMeta,
+    data: Vec<T>,
+}
+
+#[derive(Serialize)]
+struct PaginatedResponseMeta {
+    total: i64,
+    count: usize,
+}
+
+impl<T> PaginatedResponse<T> {
+    pub fn new(total: i64, data: Vec<T>) -> Self {
+        let count = data.len();
+        let pagination = PaginatedResponseMeta {
+            total,
+            count,
+        };
+
+        Self {
+            pagination,
+            data
+        }
+    }
+}

--- a/crates/connection/src/client.rs
+++ b/crates/connection/src/client.rs
@@ -50,6 +50,9 @@ pub enum ClientError {
 
     #[error("Bootstrap keys decode failed. {0}")]
     Decode(#[from] DecodeError),
+
+    #[error("Player has been banned.")]
+    Banned,
 }
 
 #[derive(Debug, Error)]

--- a/crates/connection/src/crypto.rs
+++ b/crates/connection/src/crypto.rs
@@ -1,6 +1,5 @@
 use std::ffi::c_void;
 use std::io::{self, Read};
-use std::sync::OnceLock;
 use libsodium_sys::{
     crypto_kx_PUBLICKEYBYTES,
     crypto_kx_SECRETKEYBYTES,

--- a/crates/database/migrations/20240817234223_create_bans_table.sql
+++ b/crates/database/migrations/20240817234223_create_bans_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE bans (
+    ban_id SERIAL PRIMARY KEY,
+    external_id VARCHAR NOT NULL
+);

--- a/crates/message/src/player.rs
+++ b/crates/message/src/player.rs
@@ -174,7 +174,7 @@ pub struct CharacterEquipment {
     pub arms: EquippedProtector,
     pub legs: EquippedProtector,
 
-    pub talismans: Vec<u32>,
+    pub accessories: Vec<u32>,
     pub quickslots: Vec<u32>,
     pub menuslots: Vec<u32>,
     pub arrows: Vec<u32>,

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -35,3 +35,4 @@ workspace = true
 
 [dependencies.waygate-config]
 workspace = true
+

--- a/crates/rpc/src/breakin.rs
+++ b/crates/rpc/src/breakin.rs
@@ -2,7 +2,6 @@ use rand::prelude::*;
 
 use waygate_connection::send_push;
 use waygate_connection::ClientSession;
-use waygate_connection::ClientSessionContainer;
 use waygate_pool::BREAKIN_POOL;
 use waygate_pool::breakin::BreakInPoolQuery;
 use waygate_message::*;
@@ -31,19 +30,14 @@ pub async fn handle_break_in_target(
     session: ClientSession,
     request: RequestBreakInTargetParams,
 ) -> HandlerResult {
-    let (player_id, external_id) = {
-        let lock = session.lock_read();
-        (lock.player_id, lock.external_id.clone())
-    };
-
     let push_payload = PushParams::Join(JoinParams {
         identifier: ObjectIdentifier {
             object_id: rand::thread_rng().gen::<i32>(),
             secondary_id: rand::thread_rng().gen::<i32>(),
         },
         join_payload: JoinPayload::BreakInTarget(BreakInTargetParams {
-            invader_player_id: player_id,
-            invader_steam_id: external_id,
+            invader_player_id: session.player_id,
+            invader_steam_id: session.external_id.clone(),
             unk1: 0x0,
             unk2: 0x0,
             play_region: 6100000,
@@ -84,20 +78,15 @@ pub async fn handle_reject_break_in_target(
     session: ClientSession,
     request: RequestRejectBreakInTargetParams,
 ) -> HandlerResult {
-    let (player_id, steam_id) = {
-        let lock = session.lock_read();
-        (lock.player_id, lock.external_id.clone())
-    };
-
     let push_payload = PushParams::Join(JoinParams {
         identifier: ObjectIdentifier {
             object_id: rand::thread_rng().gen::<i32>(),
             secondary_id: rand::thread_rng().gen::<i32>(),
         },
         join_payload: JoinPayload::RejectBreakInTarget(RejectBreakInTargetParams {
-            host_player_id: player_id,
+            host_player_id: session.player_id,
             unk1: -90,
-            host_steam_id: steam_id,
+            host_steam_id: session.external_id.clone(),
             unk2: 0,
         }),
     });

--- a/crates/rpc/src/handler.rs
+++ b/crates/rpc/src/handler.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 use waygate_message::*;
-use waygate_connection::{ClientSession, ClientSessionContainer};
+use waygate_connection::ClientSession;
 
 pub async fn handle_request(
     session: ClientSession,
@@ -9,7 +9,7 @@ pub async fn handle_request(
 ) -> HandlerResult {
     tracing::debug!(
         "dispatch_request player = {}, type= {}",
-        session.lock_read().player_id,
+        session.player_id,
         request.name(),
     );
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -15,11 +15,9 @@ pub(crate) mod matchingticket;
 
 pub use handler::handle_request;
 
-use std::{error::Error, io::{self, Read, Write}};
+use std::error::Error;
 
-use byteorder::{ReadBytesExt, WriteBytesExt, LE};
-use waygate_connection::{ClientError, ProtocolError};
-use waygate_message::{PayloadType, RequestParams, ResponseParams};
-use waygate_wire::{deserialize, serialize};
+use waygate_connection::ClientError;
+use waygate_message::ResponseParams;
 
 type HandlerResult = Result<ResponseParams, Box<dyn Error>>;

--- a/crates/rpc/src/player.rs
+++ b/crates/rpc/src/player.rs
@@ -1,4 +1,4 @@
-use waygate_connection::{ClientSession, ClientSessionContainer};
+use waygate_connection::ClientSession;
 use waygate_message::*;
 
 use crate::HandlerResult;
@@ -8,15 +8,13 @@ pub async fn handle_update_player_status(
     request: RequestUpdatePlayerStatusParams
 ) -> HandlerResult {
     {
-        let mut session = session.lock_write();
-
+        let mut game_session = session.game_session_mut();
         // YOLO it for now, client will reject unwanted invasions anyways
-        session.invadeable = request.character.online_activity == 0x1;
-
-        session.matching = Some((&request).into());
-
-        session.update_invadeability()?;
+        game_session.invadeable = request.character.online_activity == 0x1;
+        game_session.matching = Some((&request).into());
     }
+
+    session.update_invadeability()?;
 
     Ok(ResponseParams::UpdatePlayerStatus)
 }

--- a/crates/rpc/src/player.rs
+++ b/crates/rpc/src/player.rs
@@ -9,6 +9,7 @@ pub async fn handle_update_player_status(
 ) -> HandlerResult {
     {
         let mut session = session.lock_write();
+
         // YOLO it for now, client will reject unwanted invasions anyways
         session.invadeable = request.character.online_activity == 0x1;
 

--- a/crates/rpc/src/player_equipments.rs
+++ b/crates/rpc/src/player_equipments.rs
@@ -1,4 +1,4 @@
-use waygate_connection::{ClientSession, ClientSessionContainer};
+use waygate_connection::ClientSession;
 use waygate_database::database_connection;
 use waygate_message::*;
 
@@ -37,11 +37,6 @@ pub async fn handle_gr_upload_player_equipments(
     session: ClientSession,
     request: RequestGrUploadPlayerEquipmentsParams,
 ) -> HandlerResult {
-    let (player_id, session_id) = {
-        let lock = session.lock_read();
-        (lock.player_id, lock.session_id)
-    };
-
     let mut connection = database_connection().await?;
     sqlx::query("INSERT INTO player_equipments (
             player_id,
@@ -54,8 +49,8 @@ pub async fn handle_gr_upload_player_equipments(
             $3,
             $4
         )")
-        .bind(player_id)
-        .bind(session_id)
+        .bind(session.player_id)
+        .bind(session.session_id)
         .bind(request.data)
         .bind(request.pool)
         .execute(&mut *connection)

--- a/crates/rpc/src/session.rs
+++ b/crates/rpc/src/session.rs
@@ -1,7 +1,3 @@
-use std::error::Error;
-use std::sync::Arc;
-use std::sync::RwLock;
-
 use waygate_connection::ClientSession;
 
 use waygate_message::*;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -70,3 +70,6 @@ workspace = true
 
 [dependencies.waygate-rpc]
 workspace = true
+
+[dependencies.waygate-session]
+workspace = true

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "waygate-session"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies.sqlx]
+workspace = true
+
+[dependencies.thiserror]
+workspace = true
+
+[dependencies.tracing]
+workspace = true
+
+[dependencies.waygate-database]
+workspace = true

--- a/crates/session/src/ban.rs
+++ b/crates/session/src/ban.rs
@@ -1,0 +1,46 @@
+use std::error::Error;
+
+use sqlx::query;
+use sqlx::prelude::*;
+use waygate_database::database_connection;
+
+pub async fn is_banned(external_id: &str) -> Result<bool, Box<dyn Error>> {
+    let mut connection = database_connection().await?;
+
+    let is_banned: bool = query("SELECT EXISTS(SELECT 1 FROM bans WHERE external_id = $1)")
+        .bind(external_id)
+        .fetch_one(&mut *connection)
+        .await?
+        .get("exists");
+
+    Ok(is_banned)
+}
+
+#[tracing::instrument]
+pub async fn clear_bans(external_id: &str) -> Result<(), Box<dyn Error>> {
+    let mut connection = database_connection().await?;
+    sqlx::query("DELETE FROM bans WHERE external_id = $1")
+        .bind(external_id)
+        .execute(&mut *connection)
+        .await?;
+
+    Ok(())
+}
+
+#[tracing::instrument]
+pub async fn create_ban(external_id: &str) -> Result<i32, Box<dyn Error>> {
+    let mut connection = database_connection().await?;
+    sqlx::query("DELETE FROM bans WHERE external_id = $1")
+        .bind(external_id)
+        .execute(&mut *connection)
+        .await?;
+
+    let mut connection = database_connection().await?;
+    let ban_id: i32 = sqlx::query("INSERT INTO bans (external_id) VALUES ($1) RETURNING ban_id")
+        .bind(external_id)
+        .fetch_one(&mut *connection)
+        .await?
+        .get("ban_id");
+
+    Ok(ban_id)
+}

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -1,0 +1,3 @@
+mod ban;
+
+pub use ban::*;


### PR DESCRIPTION
Implements endpoints for banning players on the JSON API.

### Banning a player. 
Curl example (76561197960287930 = Gabe Newell):
```bash
curl -v -X POST http://localhost:10902/ban \
    --header "X-Auth-Token: <API KEY>" \
    --header "Content-Type: application/json" \
    --data '{"external_id":"76561197960287930"}'
```
This endpoint responds with a `i32`, the ID of the ban in the database.

### Unbanning a player.
Curl example:
```bash
curl -v -X DELETE http://localhost:10902/ban/76561197960287930 \
    --header "X-Auth-Token: <API KEY>" \
    --header "Content-Type: application/json"
```
This endpoint responds with a `bool`, indicating whether or not the entry was removed.


### Listing all bans.
Curl example:
```bash
curl -v -X GET http://localhost:10902/ban\?limit\=10\&offset\=0 \
    --header "X-Auth-Token: <API KEY>" \
    --header "Content-Type: application/json"
```
This endpoint responds with a list of all bans currently in effect.
```json
{
    "pagination": {
        "total": 23,
        "count": 10
    },
    "data": [
        {
            "ban_id": 6,
            "external_id": "76561197960287930"
        }
        // ...
    ]
}
```

Currently ban status is only checked on session creation and refresh. If you ban a player the server will not immediately disconnect the session for that player. Adding this requires a rework of the session tracking.